### PR TITLE
Fixed RT-126: syntax highlighting for RAML tag

### DIFF
--- a/app/vendor/scripts/yaml.js
+++ b/app/vendor/scripts/yaml.js
@@ -1,102 +1,126 @@
-CodeMirror.defineMode("yaml", function() {
+'use strict';
+
+var CodeMirror = window.CodeMirror;
+
+CodeMirror.defineMode('yaml', function () {
 
   var cons = ['true', 'false', 'on', 'off', 'yes', 'no'];
-  var keywordRegex = new RegExp("\\b(("+cons.join(")|(")+"))$", 'i');
+  var keywordRegex = new RegExp('\\b((' + cons.join(')|(') + '))$', 'i');
 
   return {
     token: function(stream, state) {
       var ch = stream.peek();
       var esc = state.escaped;
       state.escaped = false;
-      /* comments */
-      if (ch == "#" && (stream.pos == 0 || /\s/.test(stream.string.charAt(stream.pos - 1)))) {
-        stream.skipToEnd(); return "comment";
+
+      /* RAML tag */
+      if (ch === '#' && stream.string.replace(/^\s+|\s+$/g, '').toUpperCase() === '#%RAML 0.2') {
+        stream.skipToEnd();
+        return 'raml-tag';
       }
+      /* comments */
+      if (ch === '#' && (stream.pos === 0 || /\s/.test(stream.string.charAt(stream.pos - 1)))) {
+        stream.skipToEnd();
+        return 'comment';
+      }
+
       if (state.literal && stream.indentation() > state.keyCol) {
-        stream.skipToEnd(); return "none";
-      } else if (state.literal) { state.literal = false; }
+        stream.skipToEnd();
+        return 'none';
+      } else if (state.literal) {
+        state.literal = false;
+      }
+
       if (stream.sol()) {
         state.keyCol = 0;
         state.pair = false;
         state.pairStart = false;
+
         /* document start */
-        if(stream.match(/---/)) { return "def"; }
+        if(stream.match(/---/)) {
+          return 'def';
+        }
         /* document end */
-        if (stream.match(/\.\.\./)) { return "def"; }
+        if (stream.match(/\.\.\./)) {
+          return 'def';
+        }
         /* array list item */
-        if (stream.match(/\s*-\s+/)) { return 'meta'; }
+        if (stream.match(/\s*-\s+/)) {
+          return 'meta';
+        }
       }
       /* pairs (associative arrays) -> key */
       if (!state.pair && stream.match(/^\s*([a-z0-9\?\/\{\}\._-])+(?=\s*:)/i)) {
         var key = stream.string.replace(/^\s+|\s+$/g, '').split(':')[0];
         var level = stream.string.split('  ').length - 1;
-        
+
         state.pair = true;
         state.keyCol = stream.indentation();
 
-        if (level <= state.traitLevel) {
-          state.traitLevel = 0;
-          state.insideTraits = false;
-        }
-        if ("traits".indexOf(key) >= 0) {
-          state.traitLevel = level;
-          state.insideTraits = true;
-        }
-
+        /* methods */
         if (level <= state.methodLevel || key.indexOf('/') === 0) {
           state.methodLevel = 0;
           state.insideMethod = false;
         }
-        if ("get|get?|put|put?|post|post?|patch|patch?|delete|delete?|head|head?|options|options?".indexOf(key) >= 0) {
+        if ('get|get?|put|put?|post|post?|patch|patch?|delete|delete?|head|head?|options|options?'.indexOf(key) >= 0) {
           state.methodLevel = level;
           state.insideMethod = true;
         }
-
-        if ("get|get?|put|put?|post|post?|patch|patch?|delete|delete?|head|head?|options|options?".indexOf(key) >= 0) {
-          return "method-title";
+        if ('get|get?|put|put?|post|post?|patch|patch?|delete|delete?|head|head?|options|options?'.indexOf(key) >= 0) {
+          return 'method-title';
         }
-
-        if ("traits".indexOf(key) >= 0) {
-          return "trait-title";
-        }
-
         if (state.insideMethod) {
-          return "method-content"
+          return 'method-content';
+        }
+        /* traits */
+        if (level <= state.traitLevel) {
+          state.traitLevel = 0;
+          state.insideTraits = false;
+        }
+        if ('traits'.indexOf(key) >= 0) {
+          state.traitLevel = level;
+          state.insideTraits = true;
+        }
+        if ('traits'.indexOf(key) >= 0) {
+          return 'trait-title';
         }
         if (state.insideTraits) {
-          return "trait-content";
+          return 'trait-content';
         }
-        if (stream.string.toLowerCase().indexOf('tag:raml.org') >= 0) {
-          return "raml-tag";
-        }
+        /* resources */
         if (key.indexOf('/') === 0) {
-          return "resource";
+          return 'resource';
         }
-        
-        return "key";
+
+        return 'key';
       }
       if (state.pair && stream.match(/^:\s*/)) { state.pairStart = true; return 'meta'; }
 
       /* inline pairs/lists */
       if (stream.match(/^(\{|\}|\[|\])/)) {
-        if (ch == '{')
+        if (ch === '{') {
           state.inlinePairs++;
-        else if (ch == '}')
+        }
+        else if (ch === '}') {
           state.inlinePairs--;
-        else if (ch == '[')
+        }
+        else if (ch === '[') {
           state.inlineList++;
-        else
+        }
+        else {
           state.inlineList--;
+        }
         return 'meta';
       }
 
       /* list seperator */
-      if (state.inlineList > 0 && !esc && ch == ',') {
+      if (state.inlineList > 0 && !esc && ch === ',') {
         stream.next();
         return 'meta';
       }
+
       /* pairs seperator */
-      if (state.inlinePairs > 0 && !esc && ch == ',') {
+      if (state.inlinePairs > 0 && !esc && ch === ',') {
         state.keyCol = 0;
         state.pair = false;
         state.pairStart = false;
@@ -107,19 +131,28 @@ CodeMirror.defineMode("yaml", function() {
       /* start of value of a pair */
       if (state.pairStart) {
         /* block literals */
-        if (stream.match(/^\s*(\||\>)\s*/)) { state.literal = true; return 'meta'; };
+        if (stream.match(/^\s*(\||\>)\s*/)) {
+          state.literal = true;
+          return 'meta';
+        }
         /* references */
-        if (stream.match(/^\s*(\&|\*)[a-z0-9\._-]+\b/i)) { return 'variable-2'; }
+        if (stream.match(/^\s*(\&|\*)[a-z0-9\._-]+\b/i)) {
+          return 'variable-2';
+        }
         /* numbers */
-        if (state.inlinePairs == 0 && stream.match(/^\s*-?[0-9\.\,]+\s?$/)) { return 'number'; }
-        if (state.inlinePairs > 0 && stream.match(/^\s*-?[0-9\.\,]+\s?(?=(,|}))/)) { return 'number'; }
+        if (state.inlinePairs === 0 && stream.match(/^\s*-?[0-9\.\,]+\s?$/)) {
+          return 'number';
+        }
+        if (state.inlinePairs > 0 && stream.match(/^\s*-?[0-9\.\,]+\s?(?=(,|}))/)) {
+          return 'number';
+        }
         /* keywords */
         if (stream.match(keywordRegex)) { return 'keyword'; }
       }
 
       /* nothing found, continue */
       state.pairStart = false;
-      state.escaped = (ch == '\\');
+      state.escaped = (ch === '\\');
       stream.next();
       return null;
     },
@@ -137,4 +170,4 @@ CodeMirror.defineMode("yaml", function() {
   };
 });
 
-CodeMirror.defineMIME("text/x-yaml", "yaml");
+CodeMirror.defineMIME('text/x-yaml', 'yaml');

--- a/app/views/raml-editor-main.tmpl.html
+++ b/app/views/raml-editor-main.tmpl.html
@@ -1,7 +1,7 @@
 <div role="raml-editor" ng-controller="ramlMain">
   <div role="editor">
     <div style="height:inherit"><textarea id="code" name="code" style="display: none;">
-%TAG ! tag:raml.org,0.1:
+#%RAML 0.2
 ---
 title: Test
 baseUri: http://www.api.com/{version}/{company}


### PR DESCRIPTION
Now the RAML tag is highlighted in green.
I also fixed all the JSHints warnings of the syntax highlighting module (inherited from CodeMirror, now owned)

![image](https://f.cloud.github.com/assets/1288192/1076324/91afb5ac-14e0-11e3-9e1e-f7ba16a268e3.png)
