### PR TITLE
Remove dependencies on console dependencies.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -41,6 +41,7 @@
     <!-- endbuild -->
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="scripts/app.js"></script>
+    <script src="scripts/common/eventService.js"></script>
     <script src="scripts/services/code-mirror.js"></script>
     <script src="scripts/services/code-mirror-errors.js"></script>
     <script src="scripts/services/raml-hint.js"></script>

--- a/app/scripts/common/eventService.js
+++ b/app/scripts/common/eventService.js
@@ -1,14 +1,23 @@
-angular.module('helpers')
-  .factory('eventService', function ($rootScope) {
-    var service = {};
+(function() {
+  var module;
 
-    service.broadcast = function (eventName, data) {
-      $rootScope.$broadcast(eventName, data);
-    };
+  try {
+    module = angular.module('helpers');
+  } catch (e) {
+    module = angular.module('helpers', []);
+  }
 
-    service.on = function (eventName, handler) {
-      $rootScope.$on(eventName, handler);
-    };
+  module.factory('eventService', function ($rootScope) {
+      var service = {};
 
-    return service;
-});
+      service.broadcast = function (eventName, data) {
+        $rootScope.$broadcast(eventName, data);
+      };
+
+      service.on = function (eventName, handler) {
+        $rootScope.$on(eventName, handler);
+      };
+
+      return service;
+  });
+})();

--- a/app/scripts/controllers/raml-editor-main.js
+++ b/app/scripts/controllers/raml-editor-main.js
@@ -21,6 +21,7 @@ angular.module('ramlEditorApp')
       ramlParser.load(definition).then(function (result) {
         codeMirrorErrors.clearAnnotations();
         eventService.broadcast('event:raml-parsed', result);
+        $scope.$digest();
       }, function (error) {
         eventService.broadcast('event:raml-parser-error', error);
       });


### PR DESCRIPTION
The editor requires a module defined by console called helpers. The
newer console version does not provide this module so make the editor
resillient to different console versions.
