### PR TITLE
Remove dependencies on console dependencies.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -41,6 +41,7 @@
     <!-- endbuild -->
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="scripts/app.js"></script>
+    <script src="scripts/common/eventService.js"></script>
     <script src="scripts/services/config.js"></script>
     <script src="scripts/services/code-mirror.js"></script>
     <script src="scripts/services/event.js"></script>

--- a/app/scripts/common/eventService.js
+++ b/app/scripts/common/eventService.js
@@ -1,14 +1,23 @@
-angular.module('helpers')
-  .factory('eventService', function ($rootScope) {
-    var service = {};
+(function() {
+  var module;
 
-    service.broadcast = function (eventName, data) {
-      $rootScope.$broadcast(eventName, data);
-    };
+  try {
+    module = angular.module('helpers');
+  } catch (e) {
+    module = angular.module('helpers', []);
+  }
 
-    service.on = function (eventName, handler) {
-      $rootScope.$on(eventName, handler);
-    };
+  module.factory('eventService', function ($rootScope) {
+      var service = {};
 
-    return service;
-});
+      service.broadcast = function (eventName, data) {
+        $rootScope.$broadcast(eventName, data);
+      };
+
+      service.on = function (eventName, handler) {
+        $rootScope.$on(eventName, handler);
+      };
+
+      return service;
+  });
+})();

--- a/app/scripts/controllers/raml-editor-main.js
+++ b/app/scripts/controllers/raml-editor-main.js
@@ -3,7 +3,7 @@ angular.module('ramlEditorApp')
   .constant('UPDATE_RESPONSIVENESS_INTERVAL', 300)
   .value('afterBootstrap', function () { })
   .controller('ramlMain', function (AUTOSAVE_INTERVAL, UPDATE_RESPONSIVENESS_INTERVAL,
-    $scope, safeApply, ramlReader, ramlParser,
+    $scope, safeApply, ramlParser,
     ramlRepository, eventService, codeMirror, codeMirrorErrors, afterBootstrap,
     config) {
     var editor, currentUpdateTimer, saveTimer;
@@ -40,8 +40,9 @@ angular.module('ramlEditorApp')
       var definition = args;
       $scope.errorMessage = '';
       ramlParser.load(definition).then(function (result) {
-        var readData = ramlReader.read(result);
-        eventService.broadcast('event:raml-parsed', readData);
+        codeMirrorErrors.clearAnnotations();
+        eventService.broadcast('event:raml-parsed', result);
+        $scope.$digest();
       }, function (error) {
         eventService.broadcast('event:raml-parser-error', error);
       });
@@ -50,11 +51,9 @@ angular.module('ramlEditorApp')
     eventService.on('event:raml-parsed', function (e, args) {
       var definition = args;
       codeMirrorErrors.clearAnnotations();
-      definition.baseUri = ramlReader.processBaseUri(definition);
-      $scope.baseUri = definition.baseUri;
       $scope.title = definition.title;
       $scope.version = definition.version;
-      eventService.broadcast('event:raml-operation-list-published', definition.resources);
+      eventService.broadcast('event:raml-operation-list-published', definition);
       $scope.hasErrors = false;
       safeApply();
     });

--- a/app/vendor/scripts/raml-console.js
+++ b/app/vendor/scripts/raml-console.js
@@ -532,14 +532,16 @@ angular.module('ramlConsoleApp')
                 $scope.consoleSettings = { displayTryIt: true };
 
                 $rootScope.$on('event:raml-parsed', function (e, args) {
+                    var definition = ramlReader.read(args);
                     $scope.baseUri = ramlReader.processBaseUri(args);
-                    $scope.resources = args.resources;
+                    $scope.resources = definition.resources;
                     $scope.documentation = args.documentation;
                     $scope.$apply();
                 });
             }
         };
     });
+
 'use strict';
 
 angular.module('ramlConsoleApp')
@@ -553,16 +555,15 @@ angular.module('ramlConsoleApp')
                 'id': '@',
                 'src': '@'
             },
-            controller: function ($scope, $element, $attrs, ramlParser, ramlReader) {
+            controller: function ($scope, $element, $attrs, ramlParser) {
                 ramlParser.loadFile($attrs.src)
                     .done(function (result) {
-                        var readData = ramlReader.read(result);
-                        console.log(readData);
-                        $rootScope.$emit('event:raml-parsed', readData);
+                        $rootScope.$emit('event:raml-parsed', result);
                     });
             }
         };
     });
+
 'use strict';
 
 angular.module('ramlConsoleApp')
@@ -627,11 +628,11 @@ angular.module('ramlConsoleApp')
         $scope.init();
     });
 angular.module('ramlConsoleApp')
-    .controller('ramlOperationList', function ($scope) {
+    .controller('ramlOperationList', function ($scope, ramlReader) {
         $scope.model = null;
 
         $scope.$on('event:raml-operation-list-published', function (e, eventData) {
-            $scope.resources = eventData;
+            $scope.resources = ramlReader.read(eventData).resources;
         });
 
         $scope.$on('event:raml-sidebar-clicked', function (e, eventData) {
@@ -642,6 +643,7 @@ angular.module('ramlConsoleApp')
             }
         });
     });
+
 angular.module('ramlConsoleApp')
     .controller('ramlDocumentation', function ($scope) {
         $scope.model = null;


### PR DESCRIPTION
The editor requires a module defined by console called helpers. The
newer console version does not provide this module so make the editor
resillient to different console versions.
