### PR TITLE
Upgraded api-console

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,7 +46,7 @@
     <script src="bower_components/showdown/src/showdown.js"></script>
 
     <script src="bower_components/raml-js-parser/dist/raml-parser.js"></script>
-    <script src="bower_components/api-console/dist/app.js"></script>
+    <script src="bower_components/api-console/dist/scripts/app.js"></script>
     <script src="bower_components/raml-grammar/dist/suggest.js"></script>
     <!-- endbuild -->
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "angular": "PatternConsulting/bower-angular#1.1.5",
     "es5-shim": "~2.0.8",
     "showdown": "~0.3.1",
-    "api-console": "mulesoft/api-console#27b0f77538d004ff5a032f93b4891e8f2a7a984e",
+    "api-console": "mulesoft/api-console#24e11afce1142475662f998b2516231637f5758f",
     "raml-grammar": "mulesoft/raml-grammar#6081fc41c54a313f3bb48d3d27e2d7ac11519d0b",
     "raml-js-parser": "raml-org/raml-js-parser#8308aea2839a6683ee026228e7a2177fe834a6c0"
   },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
       'bower_components/sinonjs/sinon.js',
 
       'bower_components/raml-js-parser/dist/raml-parser.js',
-      'bower_components/api-console/dist/app.js',
+      'bower_components/api-console/dist/scripts/app.js',
       'bower_components/raml-grammar/dist/suggest.js',
 
       'app/scripts/app.js',


### PR DESCRIPTION
We've improved our build process in the console, which included a breaking change to the editor. This pull-request updates designer to use the new path to app.js.

Note, when merging this in, you'll have to reinstall the console with bower on your local machines - this is because we're git ignoring bower_components. It might make sense to explicitly check these in, so that unaware developers won't have things break unexpectedly.
