### PR TITLE
Enable toggling light/dark themes

### DIFF
--- a/app/scripts/controllers/raml-editor-main.js
+++ b/app/scripts/controllers/raml-editor-main.js
@@ -325,6 +325,10 @@ angular.module('ramlEditorApp')
       $scope.save();
     });
 
+    eventService.on('event:toggle-theme', function () {
+      $scope.setTheme(($scope.theme == 'dark') ? 'light' : 'dark');
+    });
+
     $scope.init = function () {
       $scope.raml = {};
       $scope.definition = '';

--- a/app/scripts/services/code-mirror.js
+++ b/app/scripts/services/code-mirror.js
@@ -172,9 +172,10 @@ angular.module('codeMirror', ['raml', 'ramlEditorApp', 'codeFolding'])
         tabSize: 2,
         extraKeys: {
           'Ctrl-Space': 'autocomplete',
-          'Cmd-s': 'save',
-          'Ctrl-s': 'save',
-          'Shift-Tab': 'indentLess'
+          'Cmd-S': 'save',
+          'Ctrl-S': 'save',
+          'Shift-Tab': 'indentLess',
+          'Shift-Ctrl-T': 'toggleTheme'
         },
         keyMap: 'tabSpace',
         foldGutter: foldGutterConfig,
@@ -236,6 +237,10 @@ angular.module('codeMirror', ['raml', 'ramlEditorApp', 'codeFolding'])
         CodeMirror.showHint(cm, CodeMirror.hint.javascript, {
           ghosting: true
         });
+      };
+
+      CodeMirror.commands.toggleTheme = function (cm) {
+        eventService.broadcast('event:toggle-theme');
       };
 
       CodeMirror.defineMode('raml', codeMirrorHighLight.highlight);


### PR DESCRIPTION
It would be great to be able to switch between dark and light theme for APIHub. The current dark theme is very hard to read on some devices.
