### PR TITLE
Fixing enter key indentation at the start of a line.

### DIFF
--- a/app/scripts/services/code-folding.js
+++ b/app/scripts/services/code-folding.js
@@ -17,18 +17,14 @@ angular.module('codeFolding', ['raml', 'lightweightParse'])
     };
   })
   .factory('hasChildren', function(ramlHint){
-    return function (cm){
+    return function (cm) {
       var editorState = ramlHint.getEditorState(cm);
 
-      var potentialChildren = ramlHint.getScopes(cm).scopeLevels[editorState.currLineTabCount > 0 ? editorState.currLineTabCount + 1 : 1], firstChild;
+      var potentialChildren = ramlHint.getScopes(cm).scopeLevels[editorState.currLineTabCount + 1];
 
-      if(potentialChildren) {
-        firstChild = potentialChildren.filter(function(line) {
-          return line === editorState.start.line + 1;
-        }).pop();
-      }
-
-      return !!firstChild;
+      return potentialChildren && potentialChildren.some(function(line) {
+        return line === editorState.start.line + 1;
+      });
     };
   })
   .factory('getParentLineNumber', function (getScopes, getEditorTextAsArrayOfLines, getLineIndent, isArrayStarter) {

--- a/app/scripts/services/code-mirror.js
+++ b/app/scripts/services/code-mirror.js
@@ -127,14 +127,10 @@ angular.module('codeMirror', ['raml', 'ramlEditorApp', 'codeFolding'])
       }
 
       var offset = 0;
-      if (curLineWithoutTabs.replace(' ', '').length > 0) {
+      if (editorState.cur.ch !== 0 && curLineWithoutTabs.replace(' ', '').length > 0) {
         if (hasChildren(cm)) {
           offset = 1;
         }
-      }
-
-      if (editorState.cur.ch < editorState.curLine.length) {
-        offset = /^\s*\w+:/.test(editorState.curLine) ? 1 : 0;
       }
 
       var extraWhitespace   = '';

--- a/test/spec/code-mirror.js
+++ b/test/spec/code-mirror.js
@@ -119,7 +119,7 @@ describe('CodeMirror Service', function () {
     });
   });
 
-  describe('auto indentation', function () {
+  describe('enter key', function () {
     it('should keep the same indentation level by default', function () {
       var indentUnit = 2;
       var editor     = getEditor(codeMirror,
@@ -491,6 +491,40 @@ describe('CodeMirror Service', function () {
 
       editor.fakeKey('Enter');
       editor.getLine(5).substr(0, 3).should.be.equal(sp(3));
+    });
+
+    it('keeps indentation level after the enter key is pressed at the start of the line', function () {
+      var indentUnit = 2;
+      var editor     = getEditor(codeMirror,
+        [
+          '#%RAML 0.8',
+          'title: Test'
+        ],
+        {line: 1, ch: 0},
+        {indentUnit: indentUnit}
+      );
+
+      editor.fakeKey('Enter');
+      editor.getLine(1).should.be.equal('');
+      editor.getLine(2).should.be.equal('title: Test');
+    });
+
+    it('keeps indentation level (with children) after the enter key is pressed at the start of the line', function () {
+      var indentUnit = 2;
+      var editor     = getEditor(codeMirror,
+        [
+          '#%RAML 0.8',
+          'title: Test',
+          '/resource:',
+          '  get:'
+        ],
+        {line: 2, ch: 0},
+        {indentUnit: indentUnit}
+      );
+
+      editor.fakeKey('Enter');
+      editor.getLine(2).should.be.equal('');
+      editor.getLine(3).should.be.equal('/resource:');
     });
   });
 });


### PR DESCRIPTION
When you press enter on the first non-whitespace character,
indentation is preserved whether or not you have children.
