### PR TITLE
Remove obsolete hasChildren and getEditorState

### DIFF
--- a/app/scripts/services/code-folding.js
+++ b/app/scripts/services/code-folding.js
@@ -16,17 +16,6 @@ angular.module('codeFolding', ['raml', 'lightweightParse'])
       return isArrayStarter(firstChild);
     };
   })
-  .factory('hasChildren', function(ramlHint){
-    return function (cm) {
-      var editorState = ramlHint.getEditorState(cm);
-
-      var potentialChildren = ramlHint.getScopes(cm).scopeLevels[editorState.currLineTabCount + 1];
-
-      return potentialChildren && potentialChildren.some(function(line) {
-        return line === editorState.start.line + 1;
-      });
-    };
-  })
   .factory('getParentLineNumber', function (getScopes, getEditorTextAsArrayOfLines, getLineIndent, isArrayStarter) {
     var getParentLineNumber = function (cm, lineNumber) {
       var tabCount = getLineIndent(cm.getLine(lineNumber)).tabCount;

--- a/app/scripts/services/code-mirror.js
+++ b/app/scripts/services/code-mirror.js
@@ -4,7 +4,7 @@ angular.module('codeMirror', ['raml', 'ramlEditorApp', 'codeFolding'])
   .factory('codeMirror', function (
     ramlHint, codeMirrorHighLight, eventService, getLineIndent, generateSpaces, generateTabs,
     getParentLine, getParentLineNumber, getFirstChildLine, getFoldRange, isArrayStarter, isArrayElement,
-    hasChildren, config, extractKey
+    config, extractKey
   ) {
     var editor  = null;
     var service = {

--- a/app/scripts/services/raml-hint.js
+++ b/app/scripts/services/raml-hint.js
@@ -86,16 +86,15 @@ angular.module('ramlEditorApp')
   .factory('ramlHint', function (getLineIndent, generateTabs, getKeysToErase,
     getScopes, getEditorTextAsArrayOfLines) {
     var hinter = {};
-    var WORD = /[^\s]|[$]/;
     var RAML_VERSION = '#%RAML 0.8';
     var RAML_VERSION_PATTERN = new RegExp('^\\s*' + RAML_VERSION + '\\s*$', 'i');
 
     hinter.suggestRAML = window.suggestRAML;
 
     hinter.computePath = function (editor) {
-      var editorState = hinter.getEditorState(editor);
-      var line = editorState.cur.line;
-      var ch = editorState.cur.ch;
+      var cursor = editor.getCursor();
+      var line = cursor.line;
+      var ch = cursor.ch;
       var listsTraveled = 0;
       var lastTraveledListSpaceCount;
       var lines;
@@ -224,37 +223,6 @@ angular.module('ramlEditorApp')
       return path;
     };
 
-    hinter.getEditorState = function(editor, options) {
-      var word = options && options.word || WORD;
-      var cur = editor.getCursor(), curLine = editor.getLine(cur.line);
-      var startPos = cur.ch, endPos = startPos;
-      var currLineTabCount;
-
-      currLineTabCount = getLineIndent(curLine).tabCount;
-
-      // Handle RAML version, it should look at the entire line
-      if (cur.line === 0) {
-        word = /^|[\s]|[$]/;
-      }
-      while (endPos < curLine.length && word.test(curLine.charAt(endPos))) {
-        ++endPos;
-      }
-      while (startPos && word.test(curLine.charAt(startPos - 1))) {
-        --startPos;
-      }
-
-      var start = CodeMirror.Pos(cur.line, startPos),
-      end = CodeMirror.Pos(cur.line, endPos);
-      return {
-        curWord: startPos !== endPos && curLine.slice(startPos, endPos),
-        start: start,
-        end: end,
-        cur: cur,
-        curLine: curLine,
-        currLineTabCount: currLineTabCount
-      };
-    };
-
     hinter.getScopes = function (editor) {
       var arrayOfLines = getEditorTextAsArrayOfLines(editor);
       return getScopes(arrayOfLines);
@@ -353,11 +321,11 @@ angular.module('ramlEditorApp')
     };
 
     hinter.canAutocomplete = function (cm) {
-      var editorState    = hinter.getEditorState(cm);
-      var curLine        = editorState.curLine;
+      var cursor         = cm.getCursor();
+      var curLine        = cm.getLine(cursor.line);
       var curLineTrimmed = curLine.trim();
       var offset         = curLine.indexOf(curLineTrimmed);
-      var lineNumber     = editorState.start ? editorState.start.line : 0;
+      var lineNumber     = cursor.line;
 
       // nothing to autocomplete within comments
       // -> "#..."
@@ -365,7 +333,7 @@ angular.module('ramlEditorApp')
         var indexOf = curLineTrimmed.indexOf('#');
         return lineNumber > 0 &&
                indexOf !== -1 &&
-               editorState.cur.ch > (indexOf + offset)
+               cursor.ch > (indexOf + offset)
         ;
       })()) {
         return false;
@@ -376,7 +344,7 @@ angular.module('ramlEditorApp')
       if ((function () {
         var indexOf = curLineTrimmed.indexOf('/');
         return indexOf === 0 &&
-               editorState.cur.ch >= (indexOf + offset)
+               cursor.ch >= (indexOf + offset)
         ;
       })()) {
         return false;
@@ -387,7 +355,7 @@ angular.module('ramlEditorApp')
       if ((function () {
         var indexOf = curLineTrimmed.indexOf(': ');
         return indexOf !== -1 &&
-               editorState.cur.ch >= (indexOf + offset + 2)
+               cursor.ch >= (indexOf + offset + 2)
         ;
       })()) {
         return false;
@@ -398,7 +366,7 @@ angular.module('ramlEditorApp')
       if ((function () {
         var indexOf = curLineTrimmed.indexOf('- ');
         return indexOf === 0 &&
-               editorState.cur.ch < (indexOf + offset)
+               cursor.ch < (indexOf + offset)
         ;
       })()) {
         return false;
@@ -408,8 +376,8 @@ angular.module('ramlEditorApp')
     };
 
     hinter.autocompleteHelper = function(cm) {
-      var editorState  = hinter.getEditorState(cm);
-      var line         = editorState.curLine;
+      var cursor       = cm.getCursor();
+      var line         = cm.getLine(cursor.line);
       var word         = line.trimLeft();
       var wordIsKey;
       var suggestions;
@@ -437,7 +405,7 @@ angular.module('ramlEditorApp')
       (function () {
         var indexOf = word.indexOf('#');
         if (indexOf !== -1) {
-          if (editorState.cur.line !== 0 || indexOf !== 0) {
+          if (cursor.line !== 0 || indexOf !== 0) {
             word = word.slice(0, indexOf);
           }
         }
@@ -489,15 +457,15 @@ angular.module('ramlEditorApp')
         fromCh = line.indexOf(word);
         toCh   = fromCh + word.length;
       } else {
-        fromCh = editorState.cur.ch;
+        fromCh = cursor.ch;
         toCh   = fromCh;
       }
 
       return {
         word: word,
         list: list,
-        from: CodeMirror.Pos(editorState.cur.line, fromCh),
-        to:   CodeMirror.Pos(editorState.cur.line, toCh)
+        from: CodeMirror.Pos(cursor.line, fromCh),
+        to:   CodeMirror.Pos(cursor.line, toCh)
       };
     };
 

--- a/test/spec/raml-hint.js
+++ b/test/spec/raml-hint.js
@@ -210,61 +210,6 @@ describe('ramlEditorApp', function () {
       });
     });
 
-    describe('getEditorState', function () {
-      it('should be consistent with editor state', function () {
-        var editor = getEditor(codeMirror,
-          [
-            'title: hello',
-            'version: v1.0',
-            'baseUri: http://example.com/api',
-            '/hello:',
-            '  /bye:',
-            '    get: {}',
-            '  /ciao:',
-            '    get:'
-          ],
-          {line: 4, ch: 4}
-        );
-
-        var editorState = ramlHint.getEditorState(editor);
-        (editorState).should.be.ok;
-        (editorState.curWord).should.be.equal('/bye:');
-        (editorState.start.line).should.be.equal(4);
-        (editorState.start.ch).should.be.equal(2);
-        (editorState.end.line).should.be.equal(4);
-        (editorState.end.ch).should.be.equal(7);
-        (editorState.curLine).should.be.equal('  /bye:');
-        (editorState.currLineTabCount).should.be.equal(1);
-      });
-
-      it('curr line tab count should count only the leading spaces', function () {
-        var editor = getEditor(codeMirror,
-          [
-            'title: hello',
-            'version: v1.0',
-            'baseUri: http://example.com/api',
-            '/hello:',
-            '  /bye:',
-            '    get: {}',
-            '      description: this is a text     with spaces',
-            '  /ciao:',
-            '    get:',
-          ],
-          {line: 6, ch: 6}
-        );
-
-        var editorState = ramlHint.getEditorState(editor);
-        (editorState).should.be.ok;
-        (editorState.curWord).should.be.equal('description:');
-        (editorState.start.line).should.be.equal(6);
-        (editorState.start.ch).should.be.equal(6);
-        (editorState.end.line).should.be.equal(6);
-        (editorState.end.ch).should.be.equal(18);
-        (editorState.curLine).should.be.equal('      description: this is a text     with spaces');
-        (editorState.currLineTabCount).should.be.equal(3);
-      });
-    });
-
     describe('selectiveCloneAlternatives', function () {
       it('should clone all the keys in suggestions when keysToErase is empty', function () {
         function MyCustomClass(obj) {


### PR DESCRIPTION
<code>hasChildren</code> is no longer used by any part of the code and the only thing that is used from <code>getEditorState</code> is cursor position that can be easily taken from code mirror instance itself. Less code, less troubles!
