### PR TITLE
Bugs/previous file is not parsed when designer loads and a file is reopened 64656282

### DIFF
--- a/app/scripts/controllers/raml-editor-main.js
+++ b/app/scripts/controllers/raml-editor-main.js
@@ -172,7 +172,7 @@ angular.module('ramlEditorApp')
 
       // check for raml version tag as a very first line of the file
       contents = arguments.length > 1 ? contents : file.contents;
-      if (contents.search(/^\s*#%RAML 0.8\s*(\n|$)/) !== 0) {
+      if (contents.search(/^\s*#%RAML( \d*\.\d*)?\s*(\n|$)/) !== 0) {
         return false;
       }
 


### PR DESCRIPTION
I fixed https://www.pivotaltracker.com/story/show/64656282

And brought the RAML regexp closer to what it is in the [raml-js-parser](https://github.com/raml-org/raml-js-parser/blob/master/src/scanner.coffee#L706)
