### PR TITLE
Add root file support

### DIFF
--- a/app/scripts/controllers/raml-editor-main.js
+++ b/app/scripts/controllers/raml-editor-main.js
@@ -12,7 +12,7 @@ angular.module('ramlEditorApp')
     }
 
     function readExtFile(path) {
-      return $http.get(path, { transformResponse: null }).then(
+      return $http.get(path, {transformResponse: null}).then(
         // success
         function success(response) {
           return response.data;
@@ -201,14 +201,19 @@ angular.module('ramlEditorApp')
     };
 
     $scope.getIsFileParsable = function getIsFileParsable(file, contents) {
-      // check for file extenstion
-      if (file.name.slice(-5) !== '.raml') {
+      // check for file extension
+      if (file.extension !== 'raml') {
         return false;
       }
 
       // check for raml version tag as a very first line of the file
       contents = arguments.length > 1 ? contents : file.contents;
       if (contents.search(/^\s*#%RAML( \d*\.\d*)?\s*(\n|$)/) !== 0) {
+        return false;
+      }
+
+      // if there is root file only that file is marked as parsable
+      if ((($scope.fileBrowser || {}).rootFile || file) !== file) {
         return false;
       }
 
@@ -253,13 +258,13 @@ angular.module('ramlEditorApp')
     });
 
     (function bootstrap() {
-      $scope.currentError     = undefined;
+      $scope.currentError    = undefined;
       $scope.theme           = $rootScope.theme = config.get('theme', 'dark');
       $scope.shelf           = {};
       $scope.shelf.collapsed = JSON.parse(config.get('shelf.collapsed', 'false'));
       $scope.editor          = editor = codeMirror.initEditor();
 
-      editor.on('fold', function(cm, start, end) {
+      editor.on('fold', function (cm, start, end) {
         if (start.line <= lineOfCurrentError && lineOfCurrentError <= end.line) {
           codeMirrorErrors.displayAnnotations([{
             line:    start.line + 1,
@@ -268,7 +273,7 @@ angular.module('ramlEditorApp')
         }
       });
 
-      editor.on('unfold', function() {
+      editor.on('unfold', function () {
         var displayLine = calculatePositionOfErrorMark(lineOfCurrentError);
 
         var message = formatErrorMessage($scope.currentError.message, lineOfCurrentError, displayLine);
@@ -284,7 +289,7 @@ angular.module('ramlEditorApp')
 
       // Warn before leaving the page
       $window.onbeforeunload = function () {
-        var anyUnsavedChanges = $scope.homeDirectory.files.some(function(file) {
+        var anyUnsavedChanges = $scope.homeDirectory.files.some(function (file) {
           return file.dirty;
         });
 

--- a/app/scripts/directives/raml-editor-file-browser.js
+++ b/app/scripts/directives/raml-editor-file-browser.js
@@ -1,116 +1,165 @@
-(function() {
+(function () {
   'use strict';
 
-  angular.module('ramlEditorApp').directive('ramlEditorFileBrowser', function($rootScope, $q, $window, ramlEditorFilenamePrompt, ramlRepository, config, eventService) {
-    var controller = function($scope) {
-      var unwatchSelectedFile = angular.noop, contextMenu;
-      $scope.fileBrowser = this;
+  angular.module('ramlEditorApp')
+    .directive('ramlEditorFileBrowser', function ($rootScope, $q, $window, ramlEditorFilenamePrompt, ramlRepository, config, eventService) {
+      function Controller($scope) {
+        var fileBrowser         = this;
+        var unwatchSelectedFile = angular.noop;
+        var contextMenu         = void(0);
 
-      function promptWhenFileListIsEmpty() {
-        ramlEditorFilenamePrompt.open($scope.homeDirectory).then(function(filename) {
-          $scope.homeDirectory.createFile(filename);
+        fileBrowser.selectFile = function selectFile(file) {
+          if (fileBrowser.selectedFile === file) {
+            return;
+          }
+
+          config.set('currentFile', JSON.stringify({path: file.path, name: file.name}));
+          unwatchSelectedFile();
+
+          var isLoaded     = !file.persisted || angular.isString(file.contents);
+          var afterLoading = isLoaded ? $q.when(file) : ramlRepository.loadFile(file);
+
+          afterLoading
+            .then(function (file) {
+              fileBrowser.selectedFile = file;
+              $scope.$emit('event:raml-editor-file-selected', file);
+              unwatchSelectedFile = $scope.$watch('fileBrowser.selectedFile.contents', function (newContents, oldContents) {
+                if (newContents !== oldContents) {
+                  file.dirty = true;
+                }
+              });
+            })
+          ;
+        };
+
+        fileBrowser.saveFile = function saveFile(file) {
+          ramlRepository.saveFile(file)
+            .then(function () {
+              eventService.broadcast('event:notification', {
+                message: 'File saved.',
+                expires: true
+              });
+            })
+          ;
+        };
+
+        fileBrowser.showContextMenu = function showContextMenu(event, file) {
+          contextMenu.open(event, file);
+        };
+
+        fileBrowser.contextMenuOpenedFor = function contextMenuOpenedFor(file) {
+          return contextMenu && contextMenu.file === file;
+        };
+
+        function saveListener(e) {
+          if (e.which === 83 && (e.metaKey || e.ctrlKey) && !(e.shiftKey || e.altKey)) {
+            e.preventDefault();
+            $scope.$apply(function () {
+              fileBrowser.saveFile(fileBrowser.selectedFile);
+            });
+          }
+        }
+
+        $window.addEventListener('keydown', saveListener);
+
+        $scope.fileBrowser = fileBrowser;
+
+        $scope.registerContextMenu = function registerContextMenu(cm) {
+          contextMenu = cm;
+        };
+
+        $scope.$on('event:raml-editor-file-created', function (event, file) {
+          fileBrowser.selectFile(file);
         });
+
+        $scope.$on('event:raml-editor-file-removed', function (event, file) {
+          if (file === fileBrowser.selectedFile && $scope.homeDirectory.files.length > 0) {
+            fileBrowser.selectFile($scope.homeDirectory.files[0]);
+          }
+        });
+
+        $scope.$on('$destroy', function () {
+          $window.removeEventListener('keydown', saveListener);
+        });
+
+        function promptWhenFileListIsEmpty() {
+          ramlEditorFilenamePrompt.open($scope.homeDirectory)
+            .then(function (filename) {
+              $scope.homeDirectory.createFile(filename);
+            })
+          ;
+        }
+
+        /**
+         * Finds a root file which should have `root` property set to `true`
+         * starting at root directory and going down through hierarchy using DFS
+         * and current position pointer instead of `shift` operation which is
+         * expensive. If there are multiple root files, which should not happen,
+         * it returns the very first one and stops the search.
+         *
+         * @param rootDirectory {RamlDirectory} A root directory to start search at
+         *
+         * @returns {RamlFile} A root file which is a file with `root` property set to `true`
+         */
+        function findRootFile(rootDirectory) {
+          var queue = [rootDirectory];
+          var pos   = 0;
+
+          while (pos < queue.length) {
+            var directory = queue[pos];
+            var files     = directory.files;
+            var entity    = void(0);
+
+            for (var i = 0; i < files.length; i++) {
+              entity = files[i];
+              if (entity.type === 'file' && entity.root) {
+                return entity;
+              }
+
+              if (entity.type === 'directory') {
+                queue.push(entity);
+              }
+            }
+
+            pos += 1;
+          }
+        }
+
+        ramlRepository.getDirectory()
+          .then(function (directory) {
+            $scope.homeDirectory = directory;
+            fileBrowser.rootFile = findRootFile(directory);
+
+            $scope.$watch('homeDirectory.files', function (files) {
+              if (!files.length) {
+                setTimeout(promptWhenFileListIsEmpty, 0);
+              }
+            }, true);
+
+            if (!directory.files.length) {
+              promptWhenFileListIsEmpty();
+              return;
+            }
+
+            // selects a file in the following order:
+            //   - previously selected file
+            //   - root file
+            //   - first file
+            var currentFile = JSON.parse(config.get('currentFile', '{}'));
+            var fileToOpen  = directory.files.filter(function (file) {
+              return file.path === currentFile.path;
+            })[0] || fileBrowser.rootFile || directory.files[0];
+
+            fileBrowser.selectFile(fileToOpen);
+          })
+        ;
       }
 
-      ramlRepository.getDirectory().then(function(directory) {
-        $scope.homeDirectory = directory;
-
-        $scope.$watch('homeDirectory.files', function(files) {
-          if (files.length === 0) {
-            setTimeout(function() {
-              promptWhenFileListIsEmpty();
-            }, 0);
-          }
-        }, true);
-
-        if (directory.files.length > 0) {
-          var lastFile = JSON.parse(config.get('currentFile', '{}'));
-
-          var fileToOpen = directory.files.filter(function(file) {
-            return file.name === lastFile.name && file.path === lastFile.path;
-          })[0];
-
-          fileToOpen = fileToOpen || directory.files[0];
-
-          $scope.fileBrowser.selectFile(fileToOpen);
-        } else {
-          promptWhenFileListIsEmpty();
-        }
-      });
-
-      $scope.$on('event:raml-editor-file-created', function(event, file) {
-        $scope.fileBrowser.selectFile(file);
-      });
-
-      $scope.$on('event:raml-editor-file-removed', function(event, file) {
-        if (file === $scope.fileBrowser.selectedFile && $scope.homeDirectory.files.length > 0) {
-          $scope.fileBrowser.selectFile($scope.homeDirectory.files[0]);
-        }
-      });
-
-      this.selectFile = function(file) {
-        if ($scope.fileBrowser.selectedFile === file) {
-          return;
-        }
-
-        config.set('currentFile', JSON.stringify({ path: file.path, name: file.name }));
-        unwatchSelectedFile();
-
-        var isLoaded = !file.persisted || angular.isString(file.contents);
-        var afterLoading = isLoaded ? $q.when(file) : ramlRepository.loadFile(file);
-
-        afterLoading.then(function(file) {
-          $scope.fileBrowser.selectedFile = file;
-          $scope.$emit('event:raml-editor-file-selected', file);
-          unwatchSelectedFile = $scope.$watch('fileBrowser.selectedFile.contents', function(newContents, oldContents) {
-            if (newContents !== oldContents) {
-              file.dirty = true;
-            }
-          });
-        });
+      return {
+        restrict:    'E',
+        templateUrl: 'views/raml-editor-file-browser.tmpl.html',
+        controller:  Controller
       };
-
-      this.saveFile = function(file) {
-        ramlRepository.saveFile(file).then(function success() {
-          eventService.broadcast('event:notification', {
-            message: 'File saved.',
-            expires: true
-          });
-        });
-      };
-
-      $scope.registerContextMenu = function(cm) {
-        contextMenu = cm;
-      };
-
-      this.showContextMenu = function(event, file) {
-        contextMenu.open(event, file);
-      };
-
-      this.contextMenuOpenedFor = function(file) {
-        return contextMenu && contextMenu.file === file;
-      };
-
-      var saveListener = function(e) {
-        if (e.which === 83 && (e.metaKey || e.ctrlKey) && !(e.shiftKey || e.altKey)) {
-          e.preventDefault();
-          $scope.$apply(function() {
-            $scope.fileBrowser.saveFile($scope.fileBrowser.selectedFile);
-          });
-        }
-      };
-
-      $window.addEventListener('keydown', saveListener);
-
-      $scope.$on('$destroy', function() {
-        $window.removeEventListener('keydown', saveListener);
-      });
-    };
-
-    return {
-      restrict: 'E',
-      templateUrl: 'views/raml-editor-file-browser.tmpl.html',
-      controller: controller
-    };
-  });
+    })
+  ;
 })();

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -120,7 +120,7 @@ module.exports = function(config) {
     browsers: ['PhantomJS'],
 
     // If browser does not capture in given timeout [ms], kill it
-    captureTimeout: 60000,
+    captureTimeout: 120000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/scenario/support/local.conf.js
+++ b/scenario/support/local.conf.js
@@ -2,7 +2,7 @@ exports.config = {
 
   seleniumPort: 4444,
 
-  allScriptsTimeout: 60000,
+  allScriptsTimeout: 120000,
 
   capabilities: {
     'browserName': 'firefox'
@@ -30,7 +30,7 @@ exports.config = {
 
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 60000,
+    defaultTimeoutInterval: 120000,
     isVerbose: false,
     includeStackTrace: true
   }

--- a/test/spec/raml-editor-main.js
+++ b/test/spec/raml-editor-main.js
@@ -17,24 +17,23 @@ describe('RAML Editor Main Controller', function () {
   });
 
   beforeEach(inject(function ($injector) {
-    $rootScope = $injector.get('$rootScope');
-    $controller = $injector.get('$controller');
-    $q = $injector.get('$q');
-    $timeout = $injector.get('$timeout');
-    $confirm = $injector.get('$confirm');
-    $window = $injector.get('$window');
-    codeMirror = $injector.get('codeMirror');
-    eventService = $injector.get('eventService');
+    $rootScope      = $injector.get('$rootScope');
+    $controller     = $injector.get('$controller');
+    $q              = $injector.get('$q');
+    $timeout        = $injector.get('$timeout');
+    $confirm        = $injector.get('$confirm');
+    $window         = $injector.get('$window');
+    codeMirror      = $injector.get('codeMirror');
+    eventService    = $injector.get('eventService');
     applySuggestion = $injector.get('applySuggestion');
-    ramlRepository = $injector.get('ramlRepository');
+    ramlRepository  = $injector.get('ramlRepository');
   }));
 
   beforeEach(function () {
-    scope = $rootScope.$new();
-
+    scope  = $rootScope.$new();
     editor = getEditor(codeMirror);
 
-    codeMirror.initEditor = function (){
+    codeMirror.initEditor = function initEditor() {
       return editor;
     };
 
@@ -315,10 +314,11 @@ describe('RAML Editor Main Controller', function () {
       getIsFileParsable = scope.getIsFileParsable;
     });
 
-    it('should return false for files without ".raml" extenstion', function () {
+    it('should return false for files without ".raml" extension', function () {
       getIsFileParsable(
         {
-          name: 'myApi.json'
+          name:      'myApi.json',
+          extension: 'json'
         }
       ).should.be.false;
     });
@@ -326,8 +326,9 @@ describe('RAML Editor Main Controller', function () {
     it('should return false for files without proper version tag as the very first line', function () {
       getIsFileParsable(
         {
-          name:     'myApi.raml',
-          contents: 'title: My API'
+          name:      'myApi.raml',
+          extension: 'raml',
+          contents:  'title: My API'
         }
       ).should.be.false;
     });
@@ -335,18 +336,20 @@ describe('RAML Editor Main Controller', function () {
     it('should use passed RAML source (invalid) instead of provided by file model and return false', function () {
       getIsFileParsable(
         {
-          name:     'myApi.raml',
-          contents: ['#%RAML 0.8', '---', 'title: My API'].join('\n')
+          name:      'myApi.raml',
+          extension: 'raml',
+          contents:  ['#%RAML 0.8', '---', 'title: My API'].join('\n')
         },
         'title: My API'
       ).should.be.false;
     });
 
-    it('should return true for files with ".raml" extenstion and proper version tag as the very first line', function () {
+    it('should return true for files with ".raml" extension  and proper version tag as the very first line', function () {
       getIsFileParsable(
         {
-          name:     'myApi.raml',
-          contents: ['#%RAML 0.8', '---', 'title: My API'].join('\n')
+          name:      'myApi.raml',
+          extension: 'raml',
+          contents:  ['#%RAML 0.8', '---', 'title: My API'].join('\n')
         }
       ).should.be.true;
     });
@@ -354,8 +357,9 @@ describe('RAML Editor Main Controller', function () {
     it('should use passed RAML source (valid) instead of provided by file model and return true', function () {
       getIsFileParsable(
         {
-          name:     'myApi.raml',
-          contents: 'title: My API'
+          name:      'myApi.raml',
+          extension: 'raml',
+          contents:  'title: My API'
         },
         ['#%RAML 0.8', '---', 'title: My API'].join('\n')
       ).should.be.true;
@@ -364,10 +368,47 @@ describe('RAML Editor Main Controller', function () {
     it('should return true for version tag ending with whitespaces', function () {
       getIsFileParsable(
         {
-          name:     'myApi.raml',
-          contents: ['#%RAML 0.8 ', '---', 'title: My API'].join('\n')
+          name:      'myApi.raml',
+          extension: 'raml',
+          contents:  ['#%RAML 0.8 ', '---', 'title: My API'].join('\n')
         }
       ).should.be.true;
+    });
+
+    describe('with root file', function () {
+      beforeEach(function () {
+        scope.fileBrowser = {
+          rootFile: {
+            name:      'root.raml',
+            extension: 'raml',
+            contents:  ['#%RAML 0.8', '---', 'title: My API'].join('\n')
+          }
+        };
+      });
+
+      describe('as selected file', function () {
+        beforeEach(function () {
+          scope.fileBrowser.selectedFile = scope.fileBrowser.rootFile;
+        });
+
+        it('should return true', function () {
+          getIsFileParsable(scope.fileBrowser.selectedFile).should.be.true;
+        });
+      });
+
+      describe('not being selected', function () {
+        beforeEach(function () {
+          scope.fileBrowser.selectedFile = {
+            name:       'selected.raml',
+            extension:  'raml',
+            contents:   ['#%RAML 0.8', '---', 'title: My API'].join('\n')
+          };
+        });
+
+        it('should return false', function () {
+          getIsFileParsable(scope.fileBrowser.selectedFile).should.be.false;
+        });
+      });
     });
   });
 

--- a/test/spec/raml-repository.js
+++ b/test/spec/raml-repository.js
@@ -101,6 +101,33 @@ describe('RAML Repository', function () {
       success.firstCall.args[0].files.should.have.length(1);
       success.firstCall.args[0].files[0].should.have.property('path', '/example.raml');
     });
+
+    it('should copy `root` property of files', function () {
+      // Arrange
+      var success = sinon.stub();
+      var folder  = {
+        path:     '/',
+        name:     '/',
+        children: [
+          {
+            path:    '/file1.raml',
+            name:    'file1.raml',
+            content: '',
+            root:    true
+          }
+        ]
+      };
+
+      // Act
+      sinon.stub(fileSystem, 'directory').returns($q.when(folder));
+      ramlRepository.getDirectory('/').then(success);
+      $rootScope.$apply();
+
+      // Assert
+      success.should.have.been.called;
+      success.firstCall.args[0].files.should.have.length(1);
+      success.firstCall.args[0].files[0].should.have.property('root').and.be.true;
+    });
   });
 
   describe('loadFile', function () {
@@ -383,6 +410,16 @@ describe('RAML Repository', function () {
 
       success.should.have.been.called;
       success.firstCall.args[0].should.be.deep.equal({});
+    });
+  });
+
+  describe('RamlFile', function () {
+    it('should have a proper extension value extracted from name', function () {
+      ramlRepository.createFile('api.raml').should.have.property('extension', 'raml');
+    });
+
+    it('should not extract an extension from name started with a dot', function () {
+      ramlRepository.createFile('.raml').should.not.have.property('extension');
     });
   });
 });


### PR DESCRIPTION
- add `root` property support to RamlFile
- let file browser directive detect root file when raml repository
  gets loaded for first time
- make sure file browser prefers root file as a selected file over
  first file AND previously selected file as a selected file over root
  and first files
- let `getIsFileParsable` recognize root file and when such exists,
  make sure only that file is marked as parsable
