### PR TITLE
Make a single click toggle folder navigation

### DIFF
--- a/app/scripts/directives/raml-editor-file-browser.js
+++ b/app/scripts/directives/raml-editor-file-browser.js
@@ -88,8 +88,11 @@
         })();
 
         fileBrowser.select = function select(target) {
-          var action = target.isDirectory ? fileBrowser.selectDirectory : fileBrowser.selectFile;
-          action(target);
+          if (target.isDirectory) {
+            return fileBrowser.selectDirectory(target);
+          }
+
+          return fileBrowser.selectFile(target);
         };
 
         fileBrowser.selectFile = function selectFile(file) {
@@ -118,11 +121,6 @@
         };
 
         fileBrowser.selectDirectory = function selectDirectory(directory) {
-          if (fileBrowser.currentTarget === directory) {
-            return;
-          }
-
-          fileBrowser.currentTarget = directory;
           $scope.$emit('event:raml-editor-directory-selected', directory);
         };
 

--- a/app/views/raml-editor-file-browser.tmpl.html
+++ b/app/views/raml-editor-file-browser.tmpl.html
@@ -7,7 +7,7 @@
       directory: node.isDirectory,
       'no-drop': fileBrowser.cursorState === 'no',
       copy: fileBrowser.cursorState === 'ok'}">
-    <span class="file-name" ng-Dblclick="toggleFolderCollapse(node)">
+    <span class="file-name" ng-click="toggleFolderCollapse(node)">
       <i class="fa icon fa-caret-right fa-fw" ng-if="node.isDirectory" ng-class="{'fa-rotate-90': !collapsed}"></i>
       <i class="fa icon fa-fw" ng-class="{'fa-folder-o': node.isDirectory, 'fa-file-text-o': !node.isDirectory}"></i>
       &nbsp;{{node.name}}


### PR DESCRIPTION
Removes `currentTarget` from selecting folders which is a little odd as it currently focuses the folder menu item which should not be selectable (opinionated)
