### PR TITLE
Mocking service style

### DIFF
--- a/app/styles/less/menubar.less
+++ b/app/styles/less/menubar.less
@@ -72,15 +72,6 @@ div[role=raml-editor] .menubar {
   .menu-item-mocking-service {
     padding: 5px 10px;
 
-    .beta {
-      background-color: #859900;
-      border-radius: 10px;
-      padding: 0px 5px;
-      color: #fff;
-      font-size: xx-small;
-      margin-right: 10px;
-    }
-
     .title {
       float: left;
       margin-right: 10px;

--- a/app/views/raml-editor-main.tmpl.html
+++ b/app/views/raml-editor-main.tmpl.html
@@ -30,7 +30,7 @@
     </li>
     <li class="spacer file-absolute-path">{{getSelectedFileAbsolutePath()}}</li>
     <li class="menu-item menu-item-fr menu-item-mocking-service" ng-show="getIsMockingServiceVisible()" ng-controller="mockingServiceController" ng-click="toggleMockingService()">
-      <div class="title"><span class="beta">BETA</span>Mocking Service</div>
+      <div class="title">Mocking Service</div>
       <div class="field-wrapper" ng-class="{loading: loading}">
         <i class="fa fa-spin fa-spinner" ng-if="loading"></i>
         <div class="field" ng-if="!loading">


### PR DESCRIPTION
Removes the beta label and corrects some style changes to the right aligned menu items.

![screen shot 2014-11-19 at 12 00 21](https://cloud.githubusercontent.com/assets/1088987/5111114/b9f66768-6fe3-11e4-847b-16718b9246b0.png)

![screen shot 2014-11-19 at 12 00 36](https://cloud.githubusercontent.com/assets/1088987/5111115/bd68e984-6fe3-11e4-9596-92b1a42822f3.png)
