### PR TITLE
Fix zip file prefix search logic

### DIFF
--- a/app/scripts/services/import-service.js
+++ b/app/scripts/services/import-service.js
@@ -320,9 +320,9 @@
             var len = prefix.length > name.length ? name.length : prefix.length;
 
             // Iterate over each part and find the common prefix.
-            for (var i = 1; i < len; i++) {
-              if (name.slice(0, i).join('/') !== prefix.slice(0, i).join('/')) {
-                return name.slice(0, i - 1);
+            for (var i = 0; i < len; i++) {
+              if (name[i] !== prefix[i]) {
+                return name.slice(0, i);
               }
             }
 
@@ -330,14 +330,19 @@
           })
           .join('/');
 
+        // Return the file object with the same file names.
+        if (!prefix) {
+          return angular.extend({}, prefixedFiles);
+        }
+
         var files = {};
 
         // Iterate over the original files and create a new object.
         Object.keys(prefixedFiles).forEach(function (name) {
-          var newName = name.substr(prefix.length);
+          var newName = name.substr(prefix.length + 1);
 
           // If no text is left, it must have been the root directory.
-          if (newName !== '/') {
+          if (newName) {
             files[newName] = prefixedFiles[name];
           }
         });


### PR DESCRIPTION
Previous implementation was actually buggy compared to how the zip files were unpacked in non-Mac systems.
