### PR TITLE
Correct prefix search logic

### DIFF
--- a/app/scripts/services/import-service.js
+++ b/app/scripts/services/import-service.js
@@ -1,10 +1,10 @@
-/* global JSZip */
 (function () {
   'use strict';
 
   angular.module('ramlEditorApp')
     .service('importService', function importServiceFactory (
       $q,
+      $window,
       ramlRepository,
       importServiceConflictModal
     ) {
@@ -25,7 +25,7 @@
 
         return readFileAsText(file)
           .then(function (contents) {
-            return mergeZip(directory, contents);
+            return self.mergeZip(directory, contents);
           });
       };
 
@@ -168,7 +168,7 @@
        * @return {Promise}
        */
       self.createFile = function (directory, name, contents) {
-        return checkExistence(directory, name)
+        return self.checkExistence(directory, name)
           .then(function (option) {
             if (option === importServiceConflictModal.SKIP_FILE) {
               return;
@@ -194,6 +194,62 @@
       };
 
       /**
+       * Create a directory in the filesystem.
+       *
+       * @param  {Object}  directory
+       * @param  {String}  name
+       * @return {Promise}
+       */
+      self.createDirectory = function (directory, name) {
+        return ramlRepository.createDirectory(directory, name);
+      };
+
+      /**
+       * Merge a zip with a directory in the file system.
+       *
+       * @param  {Object}  directory
+       * @param  {String}  contents
+       * @return {Promise}
+       */
+      self.mergeZip = function (directory, contents) {
+        var zip   = new $window.JSZip(contents);
+        var files = removeCommonFilePrefixes(sanitizeZipFiles(zip.files));
+
+        return importZipFiles(directory, files);
+      };
+
+      /**
+       * Import a zip file into the current directory.
+       *
+       * @param  {Object}  directory
+       * @param  {String}  contents
+       * @return {Promise}
+       */
+      self.importZip = function (directory, contents) {
+        var zip   = new $window.JSZip(contents);
+        var files = sanitizeZipFiles(zip.files);
+
+        return importZipFiles(directory, files);
+      };
+
+      /**
+       * Check whether a file exists and make a decision based on that.
+       *
+       * @param  {Object}  directory
+       * @param  {String}  name
+       * @return {Promise}
+       */
+      self.checkExistence = function (directory, name) {
+        var path = ramlRepository.join(directory.path, name);
+
+        if (!pathExists(path)) {
+          return $q.when(null);
+        }
+
+        return importServiceConflictModal.open(path);
+      };
+
+      /**
        * Import a single file at specific path.
        *
        * @param  {Object}  directory
@@ -207,9 +263,9 @@
             if (isZip(file)) {
               var dirname = path.replace(/[\\\/][^\\\/]*$/, '');
 
-              return ramlRepository.createDirectory(directory, dirname)
+              return self.createDirectory(directory, dirname)
                 .then(function (directory) {
-                  return importZip(directory, contents);
+                  return self.importZip(directory, contents);
                 });
             }
 
@@ -229,34 +285,6 @@
       }
 
       /**
-       * Merge a zip with a directory in the file system.
-       *
-       * @param  {Object}  directory
-       * @param  {String}  contents
-       * @return {Promise}
-       */
-      function mergeZip (directory, contents) {
-        var zip   = new JSZip(contents);
-        var files = removeCommonFilePrefixes(sanitizeZipFiles(zip.files));
-
-        return importZipFiles(directory, files);
-      }
-
-      /**
-       * Import a zip file into the current directory.
-       *
-       * @param  {Object}  directory
-       * @param  {String}  contents
-       * @return {Promise}
-       */
-      function importZip (directory, contents) {
-        var zip   = new JSZip(contents);
-        var files = sanitizeZipFiles(zip.files);
-
-        return importZipFiles(directory, files);
-      }
-
-      /**
        * Import files from the zip object.
        *
        * @param  {Object}  directory
@@ -264,20 +292,20 @@
        * @return {Promise}
        */
       function importZipFiles (directory, files) {
-        var promise = $q.when(true);
+        var imports = Object.keys(files)
+          .filter(canImport)
+          .map(function (name) {
+            return function () {
+              // Directories are stored under the files object.
+              if (/\/$/.test(name)) {
+                return self.createDirectory(directory, name);
+              }
 
-        Object.keys(files).filter(canImport).forEach(function (name) {
-          promise = promise.then(function () {
-            // Directories seem to be stored under the files object.
-            if (/\/$/.test(name)) {
-              return createDirectory(directory, name);
-            }
-
-            return self.createFile(directory, name, files[name].asText());
+              return self.createFile(directory, name, files[name].asText());
+            };
           });
-        });
 
-        return promise;
+        return promiseChain(imports);
       }
 
       /**
@@ -317,10 +345,9 @@
             return name.replace(/[\\\/][^\\\/]*$/, '').split(/[\\\/]/);
           })
           .reduce(function (prefix, name) {
-            var len = prefix.length > name.length ? name.length : prefix.length;
-
-            // Iterate over each part and find the common prefix.
-            for (var i = 0; i < len; i++) {
+            // Iterate over each part and check the prefix matches. If a part
+            // does not match, return everything before it as the new prefix.
+            for (var i = 0; i < prefix.length; i++) {
               if (name[i] !== prefix[i]) {
                 return name.slice(0, i);
               }
@@ -371,23 +398,6 @@
       }
 
       /**
-       * Check whether a file exists and make a decision based on that.
-       *
-       * @param  {Object}  directory
-       * @param  {String}  name
-       * @return {Promise}
-       */
-      function checkExistence (directory, name) {
-        var path = ramlRepository.join(directory.path, name);
-
-        if (!pathExists(path)) {
-          return $q.when(null);
-        }
-
-        return importServiceConflictModal.open(path);
-      }
-
-      /**
        * Create a file in the filesystem without checking prior existence.
        *
        * @param  {Object}  directory
@@ -428,16 +438,6 @@
       }
 
       /**
-       * Create a directory in the file system.
-       *
-       * @param  {String}  name
-       * @return {Promise}
-       */
-      function createDirectory (directory, name) {
-        return ramlRepository.createDirectory(directory, name);
-      }
-
-      /**
        * Read a file object as a text file.
        *
        * @param  {File}    file
@@ -445,7 +445,7 @@
        */
       function readFileAsText (file) {
         var deferred = $q.defer();
-        var reader   = new FileReader();
+        var reader   = new $window.FileReader();
 
         reader.onload = function () {
           return deferred.resolve(reader.result);

--- a/test/spec/services/import-service.js
+++ b/test/spec/services/import-service.js
@@ -1,0 +1,96 @@
+'use strict';
+
+describe('importService', function () {
+  var $q;
+  var $window;
+  var $rootScope;
+  var importService;
+  var ramlRepository;
+
+  beforeEach(module('ramlEditorApp'));
+
+  beforeEach(inject(function ($injector) {
+    $q             = $injector.get('$q');
+    $window        = $injector.get('$window');
+    $rootScope     = $injector.get('$rootScope');
+    importService  = $injector.get('importService');
+    ramlRepository = $injector.get('ramlRepository');
+  }));
+
+  describe('zip files', function () {
+    var zipStub;
+    var getByPathStub;
+    var createFileStub;
+    var checkExistenceStub;
+    var createDirectoryStub;
+
+    beforeEach(function () {
+      var file = {
+        asText: function () { return ''; }
+      };
+
+      var directory = {};
+
+      zipStub = sinon.stub($window, 'JSZip', function () {
+        var self = {};
+
+        self.files = {
+          '/examples/': directory,
+          '/examples/account/': directory,
+          '/examples/account/item.json': file,
+          '/examples/event/': directory,
+          '/examples/event/item.json': file,
+          '/api.raml': file
+        };
+
+        return self;
+      });
+
+      getByPathStub = sinon.stub(ramlRepository, 'getByPath', function (path) {
+        return { path: path };
+      });
+
+      function resolve () {
+        return $q.when({});
+      }
+
+      createFileStub = sinon.stub(ramlRepository, 'createFile', resolve);
+      createDirectoryStub = sinon.stub(ramlRepository, 'createDirectory', resolve);
+
+      checkExistenceStub = sinon.stub(importService, 'checkExistence', resolve);
+    });
+
+    afterEach(function () {
+      zipStub.restore();
+
+      createFileStub.restore();
+      createDirectoryStub.restore();
+
+      checkExistenceStub.restore();
+    });
+
+    describe('merge directory', function () {
+      describe('with file prefix', function () {
+        it('should not remove prefixes', function () {
+          var root = ramlRepository.getByPath('/');
+
+          // Test merging of a stubbed zip file.
+          importService.mergeZip(root, '');
+
+          $rootScope.$digest();
+
+          createFileStub.should.have.callCount(3);
+          createDirectoryStub.should.have.callCount(3);
+
+          createFileStub.should.have.been.calledWith(root, '/api.raml');
+          createFileStub.should.have.been.calledWith(root, '/examples/account/item.json');
+          createFileStub.should.have.been.calledWith(root, '/examples/event/item.json');
+
+          createDirectoryStub.should.have.been.calledWith(root, '/examples/');
+          createDirectoryStub.should.have.been.calledWith(root, '/examples/account/');
+          createDirectoryStub.should.have.been.calledWith(root, '/examples/event/');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Selecting the smallest prefix iteration using `prefix.length > name.length ? name.length : prefix.length` was incorrect as a smaller name (zero length) would not be iterated and it'd return the old prefix.