### PR TITLE
Delete folders with files that start the same

### DIFF
--- a/app/scripts/directives/raml-editor-context-menu.js
+++ b/app/scripts/directives/raml-editor-context-menu.js
@@ -77,7 +77,7 @@
 
             return confirmModal.open(message, title)
               .then(function () {
-                ramlRepository.remove(target);
+                return ramlRepository.remove(target);
               })
             ;
           }

--- a/app/scripts/services/local-storage-file-system.js
+++ b/app/scripts/services/local-storage-file-system.js
@@ -109,8 +109,7 @@
       function hasChildrens(path) {
         var has = false;
         localStorageHelper.forEach(function (entry) {
-          if (entry.path.toLowerCase() !== path.toLowerCase() &&
-              entry.path.indexOf(path) === 0) {
+          if (entry.path.indexOf(path + '/') === 0) {
             has = true;
           }
         });

--- a/test/spec/local-storage-file-system.js
+++ b/test/spec/local-storage-file-system.js
@@ -174,6 +174,22 @@ describe('Local Storage File System', function () {
         $timeout.flush();
         $timeout.flush();
       });
+
+      it('should remove only the folder when it has the same prefix as a file', function () {
+        localStorage.setItem(LOCAL_PERSISTENCE_KEY + './foo', '{ "path": "/foo", "name": "foo", "type": "folder" }');
+        localStorage.setItem(LOCAL_PERSISTENCE_KEY + './foo.raml', '{ "path": "/foo.raml", "name": "foo.raml", "type": "file" }');
+
+        localStorageFileSystem.remove('/foo')
+          .then(function () {
+            return localStorageFileSystem.directory('/');
+          })
+          .then(function (folder) {
+            hasPath(folder.children, '/foo.raml').should.be.ok;
+          });
+
+        $timeout.flush();
+        $timeout.flush();
+      });
     });
 
     describe('rename', function (){


### PR DESCRIPTION
Before this, I couldn’t delete a folder that happened to have the same beginning string as an existing folder or file. For example, you can’t delete `/api` if `/api.raml` or `/apifolder` exists.